### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
 # OCP Bandcamp Plugin
 
-allows OCP to play bandcamp urls, streams will be extracted at playback time
+This plugin lets OVOS Common Play (OCP) play Bandcamp URLs. It extracts the real stream URL at playback time.
+
+## Install
+
+```bash
+pip install ovos-ocp-bandcamp-plugin
+```
+
+## Usage
+
+OCP loads this plugin through the `opm.ocp.extractor` entry point. No manual setup is needed.
+
+The plugin handles a URL in two cases:
+- The URL contains `bandcamp.`.
+- The URL uses the `bandcamp//` stream extractor ID (sei) prefix, for example `bandcamp//https://artist.bandcamp.com/track/some-song`.
+
+When OCP asks the plugin to extract a stream, the plugin calls [py_bandcamp](https://github.com/TigreGotico/py_bandcamp) to fetch the playable stream data.
+
+## Related projects
+
+- [TigreGotico/py_bandcamp](https://github.com/TigreGotico/py_bandcamp): the Bandcamp scraper this plugin uses to extract streams.
+- [OpenVoiceOS/ovos-plugin-manager](https://github.com/OpenVoiceOS/ovos-plugin-manager): defines the `OCPStreamExtractor` template this plugin implements.
+- [OpenVoiceOS/ovos-ocp-youtube-plugin](https://github.com/OpenVoiceOS/ovos-ocp-youtube-plugin): a sibling OCP stream extractor plugin for YouTube.
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
Rewrites the README in plain, direct language and expands it with an install section, a usage section describing how the plugin matches and extracts Bandcamp URLs, and a related-projects section linking py_bandcamp, ovos-plugin-manager, and the sibling ovos-ocp-youtube-plugin.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the README with installation and usage instructions.
  - Added guidance for URL handling and stream extraction.
  - Documented related projects and the Apache-2.0 license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->