### PR TITLE
fix: strip sei prefix before passing url to py_bandcamp

### DIFF
--- a/ovos_ocp_bandcamp_plugin/__init__.py
+++ b/ovos_ocp_bandcamp_plugin/__init__.py
@@ -29,6 +29,11 @@ class OCPBandcampExtractor(OCPStreamExtractor):
 
     def extract_stream(self, url, video=True):
         """ return the real uri that can be played by OCP """
+        for sei in self.supported_seis:
+            prefix = f"{sei}//"
+            if url.startswith(prefix):
+                url = url[len(prefix):]
+                break
         data = get_stream_data(url)
         data["uri"] = data.pop("stream")
         return data

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from ovos_ocp_bandcamp_plugin import (
     OCPBandcampExtractor,
@@ -45,6 +46,20 @@ class TestOCPBandcampExtractor(unittest.TestCase):
 
     def test_settings_default(self):
         self.assertEqual(self.extractor.settings, {})
+
+    def test_extract_stream_strips_sei_prefix(self):
+        """regression for https://github.com/OpenVoiceOS/ovos-ocp-bandcamp-plugin/issues/2
+
+        "bandcamp//<url>" (the sei-prefixed uri OCP hands extractors) must
+        have the "bandcamp//" prefix stripped before being handed to
+        py_bandcamp, otherwise requests blows up with
+        `InvalidSchema: No connection adapters were found for 'bandcamp//https://...'`
+        """
+        real_url = "https://dr1p.bandcamp.com/track/flowerbomb"
+        with patch("ovos_ocp_bandcamp_plugin.get_stream_data") as mocked:
+            mocked.return_value = {"stream": "https://example.com/stream.mp3"}
+            self.extractor.extract_stream(f"bandcamp//{real_url}")
+        mocked.assert_called_once_with(real_url)
 
 
 class TestOCPBandcampExtractorConfig(unittest.TestCase):


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

This fixes #2. The stream extractor passed the raw URI straight to py_bandcamp without stripping the "bandcamp//" prefix that OCP attaches to every URI before handing it to an extractor. py_bandcamp then tried to fetch that literal string as a URL, which the requests library can't parse, producing exactly the InvalidSchema error from the issue. The fix strips that prefix before calling into py_bandcamp.

A new test mocks the underlying call and confirms it's now called with the prefix stripped; it fails against the old code, where the mock still receives the raw prefixed string, and passes after the fix. Full suite: 7 of 7 passed. I also called the real extractor against the exact URL from the issue's traceback, against the live bandcamp.com site — before the fix it raises InvalidSchema, and after the fix it returns a real, playable stream URL.
